### PR TITLE
Revert "chore(deps): update actions-r-us/actions-tagger digest to 68b8860"

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@f095bcc56b7c2baf48f3ac70d6d6782f4f553222
 
       - name: Update tag
-        uses: Actions-R-Us/actions-tagger@68b8860d45b8d5a78fc2b0b4c7bb19da085b38c6
+        uses: Actions-R-Us/actions-tagger@330ddfac760021349fef7ff62b372f2f691c20fb
         with:
           publish_latest_tag: false
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Reverts redhat-plumbers-in-action/advanced-issue-labeler#174

68b8860d45b8d5a78fc2b0b4c7bb19da085b38c6 doesn't point to release. Since #174 tagging of `v2` was broken.